### PR TITLE
APIをEC2上にデプロイする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,10 +9,10 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: pass
       MYSQL_DATABASE: video_list
-      MYSQL_USER: user
+      MYSQL_USER: admin
       MYSQL_PASSWORD: pass
     ports:
-      - 3307:3306
+      - 3306:3306
     volumes:
       - $PWD/sql:/docker-entrypoint-initdb.d
 volumes:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
-spring.datasource.url=jdbc:mysql://localhost:3307/video_list
-spring.datasource.username=user
+# suppress inspection "UnusedProperty" for whole file
+spring.datasource.url=jdbc:mysql://localhost:3306/video_list
+spring.datasource.username=admin
 spring.datasource.password=pass
 mybatis.mapper-locations=classpath*:mapper/VideoMapper.xml
 mybatis.configuration.map-underscore-to-camel-case=true


### PR DESCRIPTION
# APIのデプロイ with AWS

## インフラ構成図
<img src="https://github.com/yoshiki-bull/Video-API/assets/120367482/36456f8f-a570-462d-b4c3-6fc9338d914f" width="50%">

## 動作確認
![checking](https://github.com/yoshiki-bull/Video-API/assets/120367482/4b0fb535-3855-4c96-bb1b-e527c0258e33)

## 使用したサービス・機能
- **VPC**
  - IGW
  - サブネット
  - ルートテーブル
- **EC2**
  - ALB
  - Nginx (リバースプロキシ)
- **RDS**
  - MySQL

## セキュリティグループ
- EC2
  - SSH(My IP)
  - ALBのセキュリティグループ
- RDS
  - EC2のセキュリティグループ
- ALB
  - HTTP(0.0.0.0/0) 

## デプロイまでのおおまかな手順
- **ローカルでの作業**
1. GradleでJARファイルを作成する  
```
./gradlew build(もしくはjar)
```

2. JARファイルをEC2に転送する  
```
scp -i "<秘密鍵までのパス>" build/libs/<生成されたJarファイル名> ec2-user@<パブリックDNS>:~
```

- **EC2での作業**
1. DBアクセスのための環境変数の設定
```
# 実行
vim ~/.bash_profile

# 追加
export SPRING_DATASOURCE_URL=jdbc:mysql://<RDSのエンドポイント>:3306/<DB名>
export SPRING_DATASOURCE_USERNAME=<RDS-username>
export SPRING_DATASOURCE_PASSWORD=<RDS-password>
export SPRING_DATASOURCE_DRIVER_CLASS_NAME=com.mysql.jdbc.Driver

# 編集結果の反映
source ~/.bash_profile
```

2. JARファイルの実行
```
java -jar <JARファイル>
```